### PR TITLE
Quicopsat stage2

### DIFF
--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -1120,6 +1120,7 @@ impl Recovery {
 
         // Call congestion control hooks.
         (self.cc_ops.on_packets_acked)(self, acked, epoch, now);
+
     }
 
     fn in_congestion_recovery(&self, sent_time: Instant) -> bool {
@@ -1172,7 +1173,7 @@ impl Recovery {
         if self.resume.enabled() {
             let new_cwnd = self.resume.congestion_event(self.largest_sent_pkt[epoch]);
             if new_cwnd != 0 {
-                self.congestion_window = cmp::max(new_cwnd, self.initial_window);
+                self.congestion_window = cmp::max(new_cwnd, self.max_datagram_size * MINIMUM_WINDOW_PACKETS);
             }
         }
     }

--- a/quiche/src/recovery/resume.rs
+++ b/quiche/src/recovery/resume.rs
@@ -390,8 +390,8 @@ mod tests {
     #[test]
     fn cwnd_larger_than_jump() {
         let mut r = Resume::new("");
-        r.setup(Duration::from_millis(50), 80_000);
-        r.send_packet(Some(Duration::from_millis(50)), 45_000, 50, false);
+        r.setup(Duration::from_millis(50), 100_000);
+        r.send_packet(Some(Duration::from_millis(50)), 55_000, 50, false);
 
         assert_eq!(r.cr_state, CrState::Normal);
     }
@@ -400,8 +400,8 @@ mod tests {
     #[test]
     fn rtt_less_than_half() {
         let mut r = Resume::new("");
-        r.setup(Duration::from_millis(50), 80_000);
-        r.send_packet(Some(Duration::from_millis(10)), 30_000, 10, false);
+        r.setup(Duration::from_millis(50), 100_000);
+        r.send_packet(Some(Duration::from_millis(10)), 45_000, 10, false);
 
         assert_eq!(r.cr_state, CrState::Normal);
     }
@@ -409,8 +409,8 @@ mod tests {
     #[test]
     fn rtt_greater_than_10() {
         let mut r = Resume::new("");
-        r.setup(Duration::from_millis(50), 80_000);
-        r.send_packet(Some(Duration::from_millis(600)), 30_000, 10, false);
+        r.setup(Duration::from_millis(50), 100_000);
+        r.send_packet(Some(Duration::from_millis(600)), 45_000, 10, false);
 
         assert_eq!(r.cr_state, CrState::Normal);
     }
@@ -419,17 +419,17 @@ mod tests {
     #[test]
     fn valid_rtt() {
         let mut r = Resume::new("");
-        r.setup(Duration::from_millis(50), 80_000);
+        r.setup(Duration::from_millis(50), 100_000);
         let jump = r.send_packet(Some(Duration::from_millis(60)), 20_500, 20, false);
-        assert_eq!(jump, 19_500);
+        assert_eq!(jump, 29_500);
 
         assert_eq!(r.cr_state, CrState::Unvalidated(20));
         assert_eq!(r.pipesize, 20_500);
     }
     #[test]
-    fn packet_loss_recon() {
+    fn congestion_recon() {
         let mut r = Resume::new("");
-        r.setup(Duration::from_millis(50), 80_000);
+        r.setup(Duration::from_millis(50), 100_000);
         r.congestion_event(20);
         assert_eq!(r.cr_state, CrState::Normal);
     }
@@ -444,7 +444,7 @@ mod tests {
         let mut r = Recovery::new(&cfg, "");
         let mut now = Instant::now();
 
-        r.setup_careful_resume(Duration::from_millis(50), 80_000);
+        r.setup_careful_resume(Duration::from_millis(50), 100_000);
 
         assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
 
@@ -491,7 +491,7 @@ mod tests {
         let mut r = Recovery::new(&cfg, "");
         let mut now = Instant::now();
 
-        r.setup_careful_resume(Duration::from_millis(50), 80_000);
+        r.setup_careful_resume(Duration::from_millis(50), 100_000);
 
         assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
 
@@ -580,7 +580,7 @@ mod tests {
             assert_eq!(r.bytes_in_flight, 1000 * (i + 1));
         }
 
-        assert_eq!(r.cwnd(), 40_000);
+        assert_eq!(r.cwnd(), 50_000);
 
         assert_eq!(r.resume.cr_state, CrState::Unvalidated(16));
         assert_eq!(r.resume.pipesize, 12_000);
@@ -698,7 +698,7 @@ mod tests {
         let mut r = Recovery::new(&cfg, "");
         let mut now = Instant::now();
 
-        r.setup_careful_resume(Duration::from_millis(50), 80_000);
+        r.setup_careful_resume(Duration::from_millis(50), 100_000);
 
         assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
 
@@ -888,7 +888,7 @@ mod tests {
     }
 
     #[test]
-    fn packet_loss_recon_full_reno() {
+    fn packet_loss_recon_gap_full_reno() {
         let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
         cfg.set_cc_algorithm(CongestionControlAlgorithm::Reno);
         cfg.enable_resume(true);
@@ -958,7 +958,7 @@ mod tests {
         assert_eq!(r.resume.cr_state, CrState::Normal);
     }
     #[test]
-    fn packet_loss_recon_full_cubic() {
+    fn packet_loss_recon_full_gap_cubic() {
         let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
         cfg.set_cc_algorithm(CongestionControlAlgorithm::CUBIC);
         cfg.enable_resume(true);
@@ -1041,7 +1041,7 @@ mod tests {
            // To exit from recovery
            time_sent: now,
            // More than cur_cwnd to increase cwnd
-           size: 2000,
+           size: 1200,
            delivered: 0,
            delivered_time: now,
            first_sent_time: now,
@@ -1057,7 +1057,7 @@ mod tests {
             // To exit from recovery
             time_sent: now,
             // More than cur_cwnd to increase cwnd
-            size: 2000,
+            size: 1200,
             delivered: 0,
             delivered_time: now,
             first_sent_time: now,
@@ -1067,11 +1067,373 @@ mod tests {
             rtt: Duration::ZERO,
         };
         r.process_ack(35, &p, 5_000);
-        assert_eq!(r.pipesize, 4_000);
+        assert_eq!(r.pipesize, 2_400);
         assert_eq!(r.cr_state, CrState::Validating(35));
 
     }
+    #[test]
+    fn congestion_unval() {
+        let mut r = Resume::new("");
+        r.setup(Duration::from_millis(50), 100_000);
+        r.change_state(CrState::Unvalidated(35), CarefulResumeTrigger::CwndLimited);
+        r.congestion_event(40);
+        assert_eq!(r.cr_state, CrState::SafeRetreat(40));
+    }
 
+    #[test]
+    fn pipesize_update_unval_full() {
+        let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        cfg.set_cc_algorithm(CongestionControlAlgorithm::Reno);
+        cfg.enable_resume(true);
+
+        let mut r = Recovery::new(&cfg, "");
+        let mut now = Instant::now();
+
+        r.setup_careful_resume(Duration::from_millis(50), 100_000);
+        r.resume.change_state(CrState::Unvalidated(30), CarefulResumeTrigger::CwndLimited);
+        r.resume.pipesize = 12_000;
+
+        for i in 0..80 {
+            let p = Sent {
+                pkt_num: i as u64,
+                frames: smallvec![],
+                time_sent: now,
+                time_acked: None,
+                time_lost: None,
+                size: 1200,
+                ack_eliciting: true,
+                in_flight: true,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
+                has_data: false,
+                pmtud: false,
+            };
+
+            r.on_packet_sent(
+                p,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+            );
+            assert_eq!(r.sent[packet::Epoch::Application].len(), i + 1);
+            assert_eq!(r.bytes_in_flight, 1200 * (i + 1));
+        }
+
+        assert_eq!(r.resume.cr_state, CrState::Unvalidated(30));
+        assert_eq!(r.congestion_window, 12_000);
+
+        now += Duration::from_millis(50);
+        for i in 0..30 {
+            let mut acked = ranges::RangeSet::default();
+            acked.insert(i..i+1);
+            assert_eq!(
+                r.on_ack_received(
+                    &acked,
+                    25,
+                    packet::Epoch::Application,
+                    HandshakeStatus::default(),
+                    now,
+                    "",
+                    &mut Vec::new(),
+                ),
+                Ok((0, 0))
+            );
+            assert_eq!(r.resume.cr_state, CrState::Unvalidated(30));
+            assert_eq!(r.bytes_in_flight, 96_000 - 1200*(i+1) as usize);
+            assert_eq!(r.resume.pipesize, 12_000 + 1200*(i+1) as usize);
+        }
+        // cwnd should not increase in unvalidated
+       // assert_eq!(r.congestion_window, 12_000);
+
+        let mut acked = ranges::RangeSet::default();
+        acked.insert(30..31);
+        assert_eq!(
+            r.on_ack_received(
+                &acked,
+                25,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+                &mut Vec::new(),
+            ),
+            Ok((0, 0))
+        );
+        assert_eq!(r.resume.cr_state, CrState::Validating(79));
+        assert_eq!(r.resume.pipesize, 49_200);
+        //assert_eq!(r.congestion_window, r.bytes_in_flight);
+    }
+    #[test]
+    fn packet_loss_unval_full_gap() {
+        let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        cfg.set_cc_algorithm(CongestionControlAlgorithm::Reno);
+        cfg.enable_resume(true);
+
+        let mut r = Recovery::new(&cfg, "");
+        let mut now = Instant::now();
+
+        r.setup_careful_resume(Duration::from_millis(50), 100_000);
+        r.resume.change_state(CrState::Unvalidated(30), CarefulResumeTrigger::CwndLimited);
+        r.resume.pipesize = 12_000;
+
+        for i in 0..70 {
+            let p = Sent {
+                pkt_num: i as u64,
+                frames: smallvec![],
+                time_sent: now,
+                time_acked: None,
+                time_lost: None,
+                size: 1200,
+                ack_eliciting: true,
+                in_flight: true,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
+                has_data: false,
+                pmtud: false,
+            };
+
+            r.on_packet_sent(
+                p,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+            );
+        }
+
+        now += Duration::from_millis(50);
+        for i in 0..21 {
+            let mut acked = ranges::RangeSet::default();
+            acked.insert(i..i+1);
+            assert_eq!(
+                r.on_ack_received(
+                    &acked,
+                    25,
+                    packet::Epoch::Application,
+                    HandshakeStatus::default(),
+                    now,
+                    "",
+                    &mut Vec::new(),
+                ),
+                Ok((0, 0))
+            );
+        }
+        assert_eq!(r.resume.cr_state, CrState::Unvalidated(30));
+
+        let mut acked = ranges::RangeSet::default();
+        acked.insert(30..31);
+        let _ = r.on_ack_received(
+                &acked,
+                25,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+                &mut Vec::new(),
+            );
+        assert_eq!(r.resume.cr_state, CrState::SafeRetreat(69));
+        assert_eq!(r.resume.pipesize, 38_400);
+        // cwnd is updated before pipesize is increased
+        assert_eq!(r.congestion_window, 18_600);
+
+    }
+
+    #[test]
+    fn packet_loss_unval_full_gap_small_pipe() {
+        let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        cfg.set_cc_algorithm(CongestionControlAlgorithm::Reno);
+        cfg.enable_resume(true);
+
+        let mut r = Recovery::new(&cfg, "");
+        let mut now = Instant::now();
+
+        r.setup_careful_resume(Duration::from_millis(50), 100_000);
+        r.resume.change_state(CrState::Unvalidated(20), CarefulResumeTrigger::CwndLimited);
+
+        for i in 0..20 {
+            let p = Sent {
+                pkt_num: i as u64,
+                frames: smallvec![],
+                time_sent: now,
+                time_acked: None,
+                time_lost: None,
+                size: 1200,
+                ack_eliciting: true,
+                in_flight: true,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
+                has_data: false,
+                pmtud: false,
+            };
+
+            r.on_packet_sent(
+                p,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+            );
+        }
+
+        now += Duration::from_millis(50);
+
+        let mut acked = ranges::RangeSet::default();
+        acked.insert(0..1);
+        let _ = r.on_ack_received(
+            &acked,
+            25,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+            now,
+            "",
+            &mut Vec::new(),
+        );
+
+        assert_eq!(r.resume.cr_state, CrState::Unvalidated(20));
+
+        acked.insert(5..6);
+        let _= r.on_ack_received(
+                &acked,
+                25,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+                &mut Vec::new(),
+            );
+        assert_eq!(r.resume.cr_state, CrState::SafeRetreat(19));
+        assert_eq!(r.resume.pipesize, 2_400);
+        // cwnd is updated before pipesize is increased
+       // assert_eq!(r.congestion_window, 2_400);
+
+    }
+    #[test]
+    fn congestion_validating() {
+        let mut r = Resume::new("");
+        r.setup(Duration::from_millis(50), 100_000);
+        r.change_state(CrState::Validating(100), CarefulResumeTrigger::CrMarkAcknowledged);
+        r.congestion_event(105);
+        assert_eq!(r.cr_state, CrState::SafeRetreat(100));
+    }
+
+    #[test]
+    fn pipesize_update_validating() {
+        let mut r = Resume::new("");
+        let mut now = Instant::now();
+
+        r.setup(Duration::from_millis(50), 80_000);
+        r.change_state(CrState::Validating(100), CarefulResumeTrigger::CwndLimited);
+
+        let p = Acked {
+            pkt_num: 99,
+            // To exit from recovery
+            time_sent: now,
+            // More than cur_cwnd to increase cwnd
+            size: 1200,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
+            rtt: Duration::ZERO,
+        };
+        r.process_ack(35, &p, 5_000);
+
+        let p = Acked {
+            pkt_num: 100,
+            // To exit from recovery
+            time_sent: now,
+            // More than cur_cwnd to increase cwnd
+            size: 1200,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
+            rtt: Duration::ZERO,
+        };
+        r.process_ack(105, &p, 5_000);
+        assert_eq!(r.pipesize, 2_400);
+        assert_eq!(r.cr_state, CrState::Normal);
+
+    }
+
+    #[test]
+    fn flightsize_smaller_than_pipesize_full() {
+        let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+        cfg.set_cc_algorithm(CongestionControlAlgorithm::Reno);
+        cfg.enable_resume(true);
+
+        let mut r = Recovery::new(&cfg, "");
+        let mut now = Instant::now();
+
+        r.setup_careful_resume(Duration::from_millis(50), 100_000);
+        r.resume.change_state(CrState::Unvalidated(30), CarefulResumeTrigger::CwndLimited);
+        r.resume.pipesize = 12_000;
+
+        for i in 0..70 {
+            let p = Sent {
+                pkt_num: i as u64,
+                frames: smallvec![],
+                time_sent: now,
+                time_acked: None,
+                time_lost: None,
+                size: 1200,
+                ack_eliciting: true,
+                in_flight: true,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
+                has_data: false,
+                pmtud: false,
+            };
+
+            r.on_packet_sent(
+                p,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+            );
+        }
+
+        now += Duration::from_millis(50);
+        for i in 0..31 {
+            let mut acked = ranges::RangeSet::default();
+            acked.insert(i..i+1);
+            assert_eq!(
+                r.on_ack_received(
+                    &acked,
+                    25,
+                    packet::Epoch::Application,
+                    HandshakeStatus::default(),
+                    now,
+                    "",
+                    &mut Vec::new(),
+                ),
+                Ok((0, 0))
+            );
+        }
+        assert_eq!(r.resume.cr_state, CrState::Normal);
+    }
     #[test]
     fn cr_full() {
         let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();


### PR DESCRIPTION
Patch to load CR state for previous cwnd and previous RTT from PREVIOUS_CWND_BYTES and PREVIOUS_RTT environment variables respectively. The patch has different from the current behaviour **only** in a case where both variables are supplied. 