### PR TITLE
Added comments on CR to improve logic comprehension for maintainers

### DIFF
--- a/quiche/src/recovery/cubic.rs
+++ b/quiche/src/recovery/cubic.rs
@@ -209,14 +209,18 @@ fn on_packets_acked(
 ) {
     for pkt in packets.drain(..) {
         on_packet_acked(r, &pkt, epoch, now);
-        let (new_cwnd, new_ssthresh) = r.resume.process_ack(
-            r.largest_sent_pkt[epoch], &pkt, r.bytes_in_flight);
-        if let Some(new_cwnd) = new_cwnd {
-            r.congestion_window = new_cwnd;
+        if r.resume.enabled() {
+            // Process ACKS using CR to update cwnd and ssthresh if needed
+            let (new_cwnd, new_ssthresh) = r.resume.process_ack(
+                r.largest_sent_pkt[epoch], &pkt, r.bytes_in_flight);
+            if let Some(new_cwnd) = new_cwnd {
+                r.congestion_window = new_cwnd;
+            }
+            if let Some(new_ssthresh) = new_ssthresh {
+                r.ssthresh = new_ssthresh;
+            }
         }
-        if let Some(new_ssthresh) = new_ssthresh {
-            r.ssthresh = new_ssthresh;
-        }
+
     }
 }
 

--- a/quiche/src/recovery/mod.rs
+++ b/quiche/src/recovery/mod.rs
@@ -1100,6 +1100,12 @@ impl Recovery {
     fn on_packets_acked(
         &mut self, acked: &mut Vec<Acked>, epoch: packet::Epoch, now: Instant,
     ) {
+        // MY: We cannot process the bulk ACK'd packets here and have to implement resume processing within the CC algorithm.
+        // This is because if a packet ACKs multiple receipts AND one of the received packets triggers CR state transition, 
+        // then ALL ACK'd packets would be treated with the new, transitioned, state.
+        // We do not want this behaviour, so we have to process ACKs within the CC to avoid this.
+        // For reference, see recovery/reno.rs and recovery/cubic.rs on_packets_acked()
+
         // Update delivery rate sample per acked packet.
         for pkt in acked.iter() {
             self.delivery_rate.update_rate_sample(pkt, now);

--- a/quiche/src/recovery/reno.rs
+++ b/quiche/src/recovery/reno.rs
@@ -67,14 +67,17 @@ fn on_packets_acked(
 ) {
     for pkt in packets.drain(..) {
         on_packet_acked(r, &pkt, epoch, now);
-        let (new_cwnd, new_ssthresh) = r.resume.process_ack(
-                    r.largest_sent_pkt[epoch], &pkt, r.bytes_in_flight);
-        if let Some(new_cwnd) = new_cwnd {
-                    r.congestion_window = new_cwnd;
-                }
-        if let Some(new_ssthresh) = new_ssthresh {
-                    r.ssthresh = new_ssthresh;
-                }
+        if r.resume.enabled() {
+            // Process ACKs using CR to update cwnd and ssthresh if needed
+            let (new_cwnd, new_ssthresh) = r.resume.process_ack(
+                        r.largest_sent_pkt[epoch], &pkt, r.bytes_in_flight);
+            if let Some(new_cwnd) = new_cwnd {
+                        r.congestion_window = new_cwnd;
+                    }
+            if let Some(new_ssthresh) = new_ssthresh {
+                        r.ssthresh = new_ssthresh;
+                    }
+        }
     }
 }
 


### PR DESCRIPTION
Wrapped cc-specific CR logic in if `r.resume.enabled()` block, and added comments to explain why we need to process ACKs within the CC to help future maintainers' ease of comprehension.